### PR TITLE
Remove dotenv import and update token retrieval method

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { log } from "./utils/diags.js";
 import { GetDiscordEnv } from "./utils/env.js";
 import { Client, Events, GatewayIntentBits } from "discord.js";

--- a/src/scripts/deploy-api.ts
+++ b/src/scripts/deploy-api.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { log } from "../utils/diags.js";
 import { GetDiscordEnv } from "../utils/env.js";
 import { REST, Routes } from "discord.js";

--- a/src/utils/endpoints.ts
+++ b/src/utils/endpoints.ts
@@ -20,8 +20,8 @@ Bulk overwriting commands (guild or global)
 Cleaner abstraction
 Instead of scattering fetch calls all over, you centralize them here with consistent headers, logging, and error handling.
 */
-import "dotenv/config";
 import { log } from "./diags.js";
+import { GetRequiredEnv } from "./env.js";
 
 interface DiscordRequestOptions {
 	method: string;
@@ -39,7 +39,7 @@ export async function DiscordRequest(endpoint: string, options: DiscordRequestOp
 	// original User-Agent: DiscordBot (https://github.com/discord/discord-example-app, 1.0.0)
 	const res = await fetch(url, {
 		headers: {
-			Authorization: `Bot ${process.env["DISCORD_TOKEN"]}`,
+			Authorization: `Bot ${GetRequiredEnv("DISCORD_TOKEN")}`,
 			"Content-Type": "application/json; charset=UTF-8",
 			"User-Agent": "DiscordBot (SPGA)",
 		},

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,3 +1,8 @@
+// Load dotenv only in development
+if (process.env["NODE_ENV"] !== "production") {
+	await import("dotenv/config");
+}
+
 export function GetEnv(name: string, defaultValue?: string): string | undefined {
 	const v = process.env[name];
 	return v !== undefined ? v : defaultValue;


### PR DESCRIPTION
Eliminate the dotenv import from bot and deploy-api scripts, and modify DiscordRequest to utilize GetRequiredEnv for retrieving the Discord token. This change centralizes environment variable management and ensures dotenv is only loaded in development environments.