### PR TITLE
Exclude node_modules from runtime branch during publish

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -68,6 +68,9 @@ jobs:
                   # Copy the build output to current directory
                   cp -r publish/* .
 
+                  # Ensure node_modules is not included in runtime branch
+                  rm -rf node_modules
+
                   # Add and commit changes
                   git add -A
 


### PR DESCRIPTION
Ensure that the `node_modules` directory is removed from the runtime branch when publishing to avoid unnecessary files in the build.