### PR TITLE
Update .gitignore to exclude node_modules and log files during publish

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -74,6 +74,10 @@ jobs:
                   # Ensure node_modules is not included in runtime branch
                   rm -rf node_modules
 
+                  # Create/update .gitignore to exclude node_modules
+                  echo "node_modules/" > .gitignore
+                  echo "*.log" >> .gitignore
+
                   # Add and commit changes
                   git add -A
 


### PR DESCRIPTION
Ensure that node_modules and log files are excluded from the repository during the publish process by updating the .gitignore file accordingly.