### PR TITLE
Add /trait command for Savage Worlds trait checks

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@
 import type { ChatInputCommandInteraction, SlashCommandBuilder, SlashCommandOptionsOnlyBuilder } from "discord.js";
 import ping from "./ping.js";
 import roll from "./roll.js";
+import trait from "./trait.js";
 
 export type SlashCommand = {
 	data: SlashCommandBuilder | SlashCommandOptionsOnlyBuilder;
@@ -11,7 +12,7 @@ export type SlashCommand = {
 };
 
 // keep a list for deployment
-export const slashCommandList: SlashCommand[] = [ping, roll];
+export const slashCommandList: SlashCommand[] = [ping, roll, trait];
 
 // build the name→command map safely
 export const slashCommands: Record<string, SlashCommand> = Object.fromEntries(

--- a/src/commands/trait.ts
+++ b/src/commands/trait.ts
@@ -1,0 +1,54 @@
+import { SlashCommandBuilder, type ChatInputCommandInteraction } from "discord.js";
+import { rollParsedTraitExpression, parseTraitExpression } from "../utils/game.js";
+import { formatTraitResult } from "../utils/responses.js";
+
+export default {
+	data: new SlashCommandBuilder()
+		.setName("trait")
+		.setDescription("Roll a Savage Worlds trait check with trait die + wild die (e.g., d8+1, 1d8 wd6 (+1) tn4)")
+		.addStringOption((option) =>
+			option
+				.setName("dice")
+				.setDescription("Trait expression (e.g., d8+1, 1d10 wd6 tn8, d4 wd6 (+2) tn4)")
+				.setRequired(true),
+		),
+	async execute(interaction: ChatInputCommandInteraction) {
+		const diceInput = interaction.options.getString("dice", true); // true makes it required
+
+		// Parse the trait expression
+		const parsed = parseTraitExpression(diceInput);
+		if (!parsed.traitDie || parsed.validationMessages.length > 0) {
+			let errorMsg = `Invalid trait expression: "${diceInput}"`;
+			if (parsed.validationMessages.length > 0) {
+				errorMsg += `\n❌ Errors: ${parsed.validationMessages.join(", ")}`;
+			}
+
+			// Add help information for invalid expressions
+			errorMsg += `\n\n**Help for /trait command:**\n`;
+			errorMsg += `Use trait expressions like:\n`;
+			errorMsg += `• \`d8\` - Roll d8 trait die with d6 wild die\n`;
+			errorMsg += `• \`d8+1\` - Roll d8 trait die + d6 wild die with +1 modifier\n`;
+			errorMsg += `• \`1d10 wd6 tn8\` - Roll d10 trait + d6 wild against target 8\n`;
+			errorMsg += `• \`d4 wd6 (+2) tn4\` - Roll d4 trait + d6 wild with +2 modifier against target 4\n`;
+			errorMsg += `• \`d12 wd8 th1 (+1) tn6\` - Full notation with wild die override\n`;
+
+			await interaction.reply(errorMsg);
+			return;
+		}
+
+		// Show validation warnings if any (but still roll)
+		let warningMsg = "";
+		if (parsed.validationMessages.length > 0) {
+			warningMsg = `⚠️ Warnings: ${parsed.validationMessages.join(", ")}\n`;
+		}
+
+		// Roll the parsed trait expression
+		const result = await rollParsedTraitExpression(parsed, diceInput);
+
+		// Format the result using the trait formatting function
+		const response = formatTraitResult(result);
+
+		// Send the response
+		await interaction.reply(warningMsg + response);
+	},
+};

--- a/src/tests/trait-format.test.ts
+++ b/src/tests/trait-format.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { formatTraitResult } from "../utils/responses.js";
+import { ExpressionState, type FullTraitResult, type TraitDieResult, type DiceGroupResult } from "../utils/game.js";
+
+describe("trait response formatting", () => {
+	// Helper function to create mock dice group results
+	const createMockDiceGroupResult = (sides: number, rolls: [number, boolean, boolean][]): DiceGroupResult => ({
+		originalGroup: { quantity: 1, sides, exploding: true, infinite: true, explodingNumber: sides },
+		rolls,
+		total: rolls.filter(([, , dropped]) => !dropped).reduce((sum, [value]) => sum + value, 0),
+	});
+
+	it("should format basic trait result without target number", () => {
+		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[5, false, false]]);
+		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[3, false, false]]);
+
+		const traitDieResult: TraitDieResult = {
+			traitResult,
+			wildResult,
+			chosenResult: "trait",
+			traitTotal: 5,
+			wildTotal: 3,
+			finalTotal: 5,
+			state: ExpressionState.NotApplicable,
+			isCriticalFailure: false,
+		};
+
+		const fullResult: FullTraitResult = { traitDieResult, rawExpression: "d8" };
+
+		const formatted = formatTraitResult(fullResult);
+
+		expect(formatted).toContain("> 🎲 *d8*");
+		expect(formatted).toContain("Trait Die: 1d8 [5] = **5**");
+		expect(formatted).toContain("Wild Die: 1d6 [3] = **3** discarded");
+		expect(formatted).not.toContain("CRITICAL FAILURE");
+	});
+
+	it("should format trait result with modifier and target number", () => {
+		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[4, false, false]]);
+		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[6, false, false]]);
+
+		const traitDieResult: TraitDieResult = {
+			traitResult,
+			wildResult,
+			chosenResult: "wild",
+			traitTotal: 6, // 4 + 2
+			wildTotal: 8, // 6 + 2
+			finalTotal: 8,
+			state: ExpressionState.Success,
+			isCriticalFailure: false,
+		};
+
+		const fullResult: FullTraitResult = {
+			traitDieResult,
+			globalModifier: 2,
+			targetNumber: 6,
+			rawExpression: "d8+2 tn6",
+		};
+
+		const formatted = formatTraitResult(fullResult);
+
+		expect(formatted).toContain("> 🎲 *d8+2 tn6*");
+		expect(formatted).toContain("Trait Die: 1d8 [4] +2 = **6** discarded");
+		expect(formatted).toContain("Wild Die: 1d6 [6] +2 = **8** success");
+	});
+
+	it("should format exploding dice correctly", () => {
+		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[8, true, false]]);
+		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[6, true, false]]);
+
+		const traitDieResult: TraitDieResult = {
+			traitResult,
+			wildResult,
+			chosenResult: "trait",
+			traitTotal: 8,
+			wildTotal: 6,
+			finalTotal: 8,
+			state: ExpressionState.NotApplicable,
+			isCriticalFailure: false,
+		};
+
+		const fullResult: FullTraitResult = { traitDieResult, rawExpression: "d8" };
+
+		const formatted = formatTraitResult(fullResult);
+
+		expect(formatted).toContain("Trait Die: 1d8 [8!] = **8**");
+		expect(formatted).toContain("Wild Die: 1d6 [6!] = **6** discarded");
+	});
+
+	it("should format critical failure correctly", () => {
+		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[1, false, false]]);
+		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[1, false, false]]);
+
+		const traitDieResult: TraitDieResult = {
+			traitResult,
+			wildResult,
+			chosenResult: "trait", // Even though both are 1, trait wins tie
+			traitTotal: 3, // 1 + 2
+			wildTotal: 3, // 1 + 2
+			finalTotal: 3,
+			state: ExpressionState.CriticalFailure,
+			isCriticalFailure: true,
+		};
+
+		const fullResult: FullTraitResult = {
+			traitDieResult,
+			globalModifier: 2,
+			targetNumber: 6,
+			rawExpression: "d8+2 tn6",
+		};
+
+		const formatted = formatTraitResult(fullResult);
+
+		expect(formatted).toContain("> 🎲 *d8+2 tn6*");
+		expect(formatted).toContain("Trait Die: 1d8 [1] +2 = **3**");
+		expect(formatted).toContain("Wild Die: 1d6 [1] +2 = **3**");
+		expect(formatted).toContain("❗ **CRITICAL FAILURE**");
+		// With critical failure, neither should show success/failure state
+		expect(formatted).not.toContain("success");
+		expect(formatted).not.toContain("failure");
+		expect(formatted).not.toContain("discarded");
+	});
+
+	it("should handle negative modifiers", () => {
+		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[5, false, false]]);
+		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[3, false, false]]);
+
+		const traitDieResult: TraitDieResult = {
+			traitResult,
+			wildResult,
+			chosenResult: "trait",
+			traitTotal: 3, // 5 - 2
+			wildTotal: 1, // 3 - 2
+			finalTotal: 3,
+			state: ExpressionState.Failed,
+			isCriticalFailure: false,
+		};
+
+		const fullResult: FullTraitResult = {
+			traitDieResult,
+			globalModifier: -2,
+			targetNumber: 6,
+			rawExpression: "d8-2 tn6",
+		};
+
+		const formatted = formatTraitResult(fullResult);
+
+		expect(formatted).toContain("Trait Die: 1d8 [5] -2 = **3** failure");
+		expect(formatted).toContain("Wild Die: 1d6 [3] -2 = **1** discarded");
+	});
+
+	it("should show raise result correctly", () => {
+		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[8, false, false]]);
+		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[2, false, false]]);
+
+		const traitDieResult: TraitDieResult = {
+			traitResult,
+			wildResult,
+			chosenResult: "trait",
+			traitTotal: 10, // 8 + 2
+			wildTotal: 4, // 2 + 2
+			finalTotal: 10,
+			state: ExpressionState.Raise, // 10 >= 6 + 4
+			isCriticalFailure: false,
+		};
+
+		const fullResult: FullTraitResult = {
+			traitDieResult,
+			globalModifier: 2,
+			targetNumber: 6,
+			rawExpression: "d8+2 tn6",
+		};
+
+		const formatted = formatTraitResult(fullResult);
+
+		expect(formatted).toContain("Trait Die: 1d8 [8] +2 = **10** raise");
+		expect(formatted).toContain("Wild Die: 1d6 [2] +2 = **4** discarded");
+	});
+});

--- a/src/tests/trait.test.ts
+++ b/src/tests/trait.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { parseTraitExpression, rollParsedTraitExpression, ExpressionState } from "../utils/game.js";
+
+describe("trait rolling functions", () => {
+	describe("parseTraitExpression", () => {
+		it("should parse basic trait expression", () => {
+			const result = parseTraitExpression("d8");
+
+			expect(result.traitDie.sides).toBe(8);
+			expect(result.traitDie.quantity).toBe(1);
+			expect(result.traitDie.exploding).toBe(true);
+			expect(result.traitDie.infinite).toBe(true);
+			expect(result.wildDie.sides).toBe(6);
+			expect(result.wildDie.quantity).toBe(1);
+			expect(result.wildDie.exploding).toBe(true);
+			expect(result.wildDie.infinite).toBe(true);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse trait expression with modifier", () => {
+			const result = parseTraitExpression("d8+2");
+
+			expect(result.traitDie.sides).toBe(8);
+			expect(result.globalModifier).toBe(2);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse trait expression with negative modifier", () => {
+			const result = parseTraitExpression("d10-1");
+
+			expect(result.traitDie.sides).toBe(10);
+			expect(result.globalModifier).toBe(-1);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse trait expression with wild die override", () => {
+			const result = parseTraitExpression("d12 wd8");
+
+			expect(result.traitDie.sides).toBe(12);
+			expect(result.wildDie.sides).toBe(8);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse trait expression with target number", () => {
+			const result = parseTraitExpression("d8 tn6");
+
+			expect(result.traitDie.sides).toBe(8);
+			expect(result.targetNumber).toBe(6);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse full trait expression", () => {
+			const result = parseTraitExpression("1d10 wd6 th1 (+2) tn8");
+
+			expect(result.traitDie.sides).toBe(10);
+			expect(result.wildDie.sides).toBe(6);
+			expect(result.targetHighest).toBe(1);
+			expect(result.globalModifier).toBe(2);
+			expect(result.targetNumber).toBe(8);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should handle parenthetical modifier", () => {
+			const result = parseTraitExpression("d8 (+3) tn4");
+
+			expect(result.traitDie.sides).toBe(8);
+			expect(result.globalModifier).toBe(3);
+			expect(result.targetNumber).toBe(4);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should prefer inline modifier over parenthetical modifier", () => {
+			const result = parseTraitExpression("d8+1 (+3)");
+
+			expect(result.traitDie.sides).toBe(8);
+			expect(result.globalModifier).toBe(1); // Should use inline modifier
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should validate trait die quantity", () => {
+			const result = parseTraitExpression("2d8");
+
+			expect(result.traitDie.sides).toBe(8);
+			expect(result.validationMessages).toContain("Trait die quantity must be 1, got 2");
+		});
+
+		it("should validate wild die sides", () => {
+			const result = parseTraitExpression("d8 wd1");
+
+			expect(result.validationMessages).toContain("Invalid wild die sides 1, must be 2-100");
+		});
+
+		it("should handle empty expression with defaults", () => {
+			const result = parseTraitExpression("");
+
+			expect(result.traitDie.sides).toBe(4);
+			expect(result.wildDie.sides).toBe(6);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+	});
+
+	describe("rollParsedTraitExpression", () => {
+		it("should roll trait dice correctly", () => {
+			const parsed = parseTraitExpression("d8+1 tn6");
+			const result = rollParsedTraitExpression(parsed, "d8+1 tn6");
+
+			expect(result.traitDieResult.traitResult.rolls).toHaveLength(1);
+			expect(result.traitDieResult.wildResult.rolls).toHaveLength(1);
+			expect(result.traitDieResult.traitTotal).toBe(result.traitDieResult.traitResult.total + 1);
+			expect(result.traitDieResult.wildTotal).toBe(result.traitDieResult.wildResult.total + 1);
+			expect(result.traitDieResult.finalTotal).toBe(
+				Math.max(result.traitDieResult.traitTotal, result.traitDieResult.wildTotal),
+			);
+			expect(result.targetNumber).toBe(6);
+			expect(result.globalModifier).toBe(1);
+			expect(result.rawExpression).toBe("d8+1 tn6");
+		});
+
+		it("should determine chosen result correctly", () => {
+			const parsed = parseTraitExpression("d8");
+			const result = rollParsedTraitExpression(parsed);
+
+			expect(["trait", "wild"]).toContain(result.traitDieResult.chosenResult);
+			if (result.traitDieResult.chosenResult === "trait") {
+				expect(result.traitDieResult.traitTotal).toBeGreaterThanOrEqual(result.traitDieResult.wildTotal);
+			} else {
+				expect(result.traitDieResult.wildTotal).toBeGreaterThan(result.traitDieResult.traitTotal);
+			}
+		});
+
+		it("should handle expressions without target number", () => {
+			const parsed = parseTraitExpression("d8+2");
+			const result = rollParsedTraitExpression(parsed);
+
+			expect(result.traitDieResult.state).toBe(ExpressionState.NotApplicable);
+			expect(result.targetNumber).toBeUndefined();
+		});
+
+		it("should determine success states correctly", () => {
+			// We can't predict exact dice results, but we can test the logic
+			const parsed = parseTraitExpression("d20+10 tn5"); // High modifier to ensure success
+			const result = rollParsedTraitExpression(parsed);
+
+			// With d20+10, we should almost always succeed against TN 5
+			expect([
+				ExpressionState.Success,
+				ExpressionState.Raise,
+				ExpressionState.CriticalFailure, // possible if both dice roll 1
+			]).toContain(result.traitDieResult.state);
+		});
+	});
+});

--- a/src/utils/game.ts
+++ b/src/utils/game.ts
@@ -7,6 +7,7 @@ export enum ExpressionState {
 	Failed = "failed", // < targetNumber
 	Success = "success", // >= targetNumber but < targetNumber + 4
 	Raise = "raise", // >= targetNumber + 4
+	Discarded = "discarded", // For trait rolls - the die result that wasn't used
 }
 
 export interface DiceGroup {
@@ -44,6 +45,33 @@ export interface FullRollResult {
 	expressionResults: ExpressionResult[];
 	grandTotal: number;
 	totalSuccesses?: number;
+	targetNumber?: number;
+	globalModifier?: number;
+	rawExpression?: string;
+}
+
+export interface ParsedTraitExpression {
+	traitDie: DiceGroup;
+	wildDie: DiceGroup;
+	targetHighest?: number;
+	globalModifier?: number;
+	targetNumber?: number;
+	validationMessages: string[];
+}
+
+export interface TraitDieResult {
+	traitResult: DiceGroupResult;
+	wildResult: DiceGroupResult;
+	chosenResult: "trait" | "wild";
+	traitTotal: number;
+	wildTotal: number;
+	finalTotal: number;
+	state?: ExpressionState;
+	isCriticalFailure: boolean;
+}
+
+export interface FullTraitResult {
+	traitDieResult: TraitDieResult;
 	targetNumber?: number;
 	globalModifier?: number;
 	rawExpression?: string;
@@ -531,4 +559,186 @@ export function rollDice(
 	}
 	const sum = rolls.reduce((acc, v) => acc + v[0], 0);
 	return sum;
+}
+
+export function parseTraitExpression(expression: string): ParsedTraitExpression {
+	// Clean up the expression
+	const cleanExpression = expression.replace(/\s+/g, "").toLowerCase();
+
+	// Initialize result with defaults
+	const result: ParsedTraitExpression = {
+		traitDie: { quantity: 1, sides: 4 }, // default d4
+		wildDie: { quantity: 1, sides: 6 }, // default d6
+		targetHighest: 1,
+		validationMessages: [],
+	};
+
+	// Helper function to add validation messages
+	const addValidationMessage = (message: string, details?: any) => {
+		result.validationMessages.push(message);
+		log.trace(message, details);
+	};
+
+	// Extract target number if present
+	const tnMatch = cleanExpression.match(/tn(\d+)/);
+	if (tnMatch && tnMatch[1]) {
+		result.targetNumber = parseInt(tnMatch[1]);
+	}
+
+	// Extract target highest if present
+	const thMatch = cleanExpression.match(/th(\d+)/);
+	if (thMatch && thMatch[1]) {
+		result.targetHighest = parseInt(thMatch[1]);
+	}
+
+	// Remove target number and target highest from expression for further parsing
+	let workingExpression = cleanExpression.replace(/tn\d+/, "");
+	workingExpression = workingExpression.replace(/th\d+/, "");
+
+	// Extract wild die if present (wd<n>)
+	const wildDieMatch = workingExpression.match(/wd(\d+)/);
+	if (wildDieMatch && wildDieMatch[1]) {
+		const wildSides = parseInt(wildDieMatch[1]);
+		if (wildSides >= 2 && wildSides <= 100) {
+			result.wildDie.sides = wildSides;
+		} else {
+			addValidationMessage(`Invalid wild die sides ${wildSides}, must be 2-100`);
+		}
+		workingExpression = workingExpression.replace(/wd\d+/, "");
+	}
+
+	// Parse trait die and any inline modifiers FIRST (to give priority to inline modifiers)
+	// Look for patterns like: d8, 1d8, d8+1, 1d8+2, d8-1, etc.
+	const traitDieMatch = workingExpression.match(/(\d*)d(\d+)([+-]\d+)?/);
+	if (traitDieMatch && traitDieMatch[2]) {
+		const quantity = traitDieMatch[1] ? parseInt(traitDieMatch[1]) : 1;
+		const sides = parseInt(traitDieMatch[2]);
+		const modifier = traitDieMatch[3] ? parseInt(traitDieMatch[3]) : undefined;
+
+		// Validate trait die quantity (must be 1 for trait rolls)
+		if (quantity !== 1) {
+			addValidationMessage(`Trait die quantity must be 1, got ${quantity}`);
+		}
+
+		// Validate trait die sides
+		if (sides >= 2 && sides <= 100) {
+			result.traitDie.sides = sides;
+		} else {
+			addValidationMessage(`Invalid trait die sides ${sides}, must be 2-100`);
+		}
+
+		// Handle inline modifier as global modifier (gets priority)
+		if (modifier !== undefined) {
+			result.globalModifier = modifier;
+		}
+
+		workingExpression = workingExpression.replace(/(\d*)d(\d+)([+-]\d+)?/, "");
+	}
+
+	// Extract global modifier if present: (1), (+1), (-1) - only if not already set by inline modifier
+	if (result.globalModifier === undefined) {
+		const globalModMatch = workingExpression.match(/\(([+-]?\d+)\)/);
+		if (globalModMatch && globalModMatch[1]) {
+			const modStr = globalModMatch[1];
+			result.globalModifier =
+				modStr.startsWith("+") || modStr.startsWith("-") ? parseInt(modStr) : parseInt(modStr);
+		}
+	}
+
+	// Remove global modifier from expression for further parsing
+	workingExpression = workingExpression.replace(/\([+-]?\d+\)/, "");
+
+	// Handle remaining expressions - check for just a modifier if no trait die was found
+	if (!traitDieMatch) {
+		// If no trait die found, check for just a modifier
+		const modifierMatch = workingExpression.match(/^([+-]?\d+)$/);
+		if (modifierMatch && modifierMatch[1] && result.globalModifier === undefined) {
+			result.globalModifier = parseInt(modifierMatch[1]);
+		} else if (!workingExpression.trim()) {
+			// Empty expression is ok, use defaults
+		} else {
+			addValidationMessage(`Unable to parse trait die from expression`);
+		}
+	}
+
+	// Set exploding properties for both dice
+	result.traitDie.exploding = true;
+	result.traitDie.infinite = true;
+	result.traitDie.explodingNumber = result.traitDie.sides;
+
+	result.wildDie.exploding = true;
+	result.wildDie.infinite = true;
+	result.wildDie.explodingNumber = result.wildDie.sides;
+
+	log.trace("Parsed trait expression", {
+		expression: cleanExpression,
+		traitDie: result.traitDie,
+		wildDie: result.wildDie,
+		targetNumber: result.targetNumber,
+		globalModifier: result.globalModifier,
+		targetHighest: result.targetHighest,
+		validationMessages: result.validationMessages,
+	});
+
+	return result;
+}
+
+export function rollParsedTraitExpression(parsed: ParsedTraitExpression, rawExpression?: string): FullTraitResult {
+	// Roll the trait die
+	const traitResult = rollDiceGroup(parsed.traitDie);
+
+	// Roll the wild die
+	const wildResult = rollDiceGroup(parsed.wildDie);
+
+	// Calculate totals with global modifier
+	const globalMod = parsed.globalModifier || 0;
+	const traitTotal = traitResult.total + globalMod;
+	const wildTotal = wildResult.total + globalMod;
+
+	// Determine which result to use (higher total)
+	const chosenResult = traitTotal >= wildTotal ? "trait" : "wild";
+	const finalTotal = Math.max(traitTotal, wildTotal);
+
+	// Check for critical failure (both dice rolled natural 1s)
+	const traitNaturalRolls = traitResult.rolls.map(([roll]) => roll);
+	const wildNaturalRolls = wildResult.rolls.map(([roll]) => roll);
+
+	// Critical failure occurs when both dice have at least one natural 1 in their initial rolls
+	const traitHasNatural1 = traitNaturalRolls.length > 0 && traitNaturalRolls[0] === 1;
+	const wildHasNatural1 = wildNaturalRolls.length > 0 && wildNaturalRolls[0] === 1;
+	const isCriticalFailure = traitHasNatural1 && wildHasNatural1;
+
+	// Determine expression state based on target number
+	let state: ExpressionState | undefined;
+	if (isCriticalFailure) {
+		state = ExpressionState.CriticalFailure;
+	} else if (parsed.targetNumber !== undefined) {
+		if (finalTotal >= parsed.targetNumber + 4) {
+			state = ExpressionState.Raise;
+		} else if (finalTotal >= parsed.targetNumber) {
+			state = ExpressionState.Success;
+		} else {
+			state = ExpressionState.Failed;
+		}
+	} else {
+		state = ExpressionState.NotApplicable;
+	}
+
+	const traitDieResult: TraitDieResult = {
+		traitResult,
+		wildResult,
+		chosenResult,
+		traitTotal,
+		wildTotal,
+		finalTotal,
+		state,
+		isCriticalFailure,
+	};
+
+	return {
+		traitDieResult,
+		...(parsed.targetNumber !== undefined && { targetNumber: parsed.targetNumber }),
+		...(parsed.globalModifier !== undefined && { globalModifier: parsed.globalModifier }),
+		...(rawExpression !== undefined && { rawExpression }),
+	};
 }


### PR DESCRIPTION
Implement the /trait command to allow users to roll Savage Worlds trait checks with customizable expressions. Enhance game logic for parsing trait expressions and format results for clarity. Include unit tests to ensure accuracy of parsing and rolling functionalities.