### PR TITLE
Add default target number to trait expressions

### DIFF
--- a/src/tests/trait-format.test.ts
+++ b/src/tests/trait-format.test.ts
@@ -65,16 +65,16 @@ describe("trait response formatting", () => {
 	});
 
 	it("should format exploding dice correctly", () => {
-		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[8, true, false]]);
-		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[6, true, false]]);
+		const traitResult: DiceGroupResult = createMockDiceGroupResult(8, [[9, true, false]]);
+		const wildResult: DiceGroupResult = createMockDiceGroupResult(6, [[8, true, false]]);
 
 		const traitDieResult: TraitDieResult = {
 			traitResult,
 			wildResult,
 			chosenResult: "trait",
-			traitTotal: 8,
-			wildTotal: 6,
-			finalTotal: 8,
+			traitTotal: 9,
+			wildTotal: 8,
+			finalTotal: 9,
 			state: ExpressionState.NotApplicable,
 			isCriticalFailure: false,
 		};
@@ -83,8 +83,8 @@ describe("trait response formatting", () => {
 
 		const formatted = formatTraitResult(fullResult);
 
-		expect(formatted).toContain("Trait Die: 1d8 [8!] = **8**");
-		expect(formatted).toContain("Wild Die: 1d6 [6!] = **6** discarded");
+		expect(formatted).toContain("Trait Die: 1d8 [9!] = **9**");
+		expect(formatted).toContain("Wild Die: 1d6 [8!] = **8** discarded");
 	});
 
 	it("should format critical failure correctly", () => {

--- a/src/tests/trait.test.ts
+++ b/src/tests/trait.test.ts
@@ -14,6 +14,7 @@ describe("trait rolling functions", () => {
 			expect(result.wildDie.quantity).toBe(1);
 			expect(result.wildDie.exploding).toBe(true);
 			expect(result.wildDie.infinite).toBe(true);
+			expect(result.targetNumber).toBe(4); // default target number
 			expect(result.validationMessages).toHaveLength(0);
 		});
 
@@ -95,6 +96,7 @@ describe("trait rolling functions", () => {
 
 			expect(result.traitDie.sides).toBe(4);
 			expect(result.wildDie.sides).toBe(6);
+			expect(result.targetNumber).toBe(4); // default target number
 			expect(result.validationMessages).toHaveLength(0);
 		});
 	});
@@ -128,12 +130,19 @@ describe("trait rolling functions", () => {
 			}
 		});
 
-		it("should handle expressions without target number", () => {
+		it("should use default target number when none specified", () => {
 			const parsed = parseTraitExpression("d8+2");
 			const result = rollParsedTraitExpression(parsed);
 
-			expect(result.traitDieResult.state).toBe(ExpressionState.NotApplicable);
-			expect(result.targetNumber).toBeUndefined();
+			// Should use default target number of 4
+			expect(result.targetNumber).toBe(4);
+			// State should be determined based on the default target number
+			expect([
+				ExpressionState.Success,
+				ExpressionState.Raise,
+				ExpressionState.Failed,
+				ExpressionState.CriticalFailure, // possible if both dice roll 1
+			]).toContain(result.traitDieResult.state);
 		});
 
 		it("should determine success states correctly", () => {

--- a/src/utils/game.ts
+++ b/src/utils/game.ts
@@ -570,6 +570,7 @@ export function parseTraitExpression(expression: string): ParsedTraitExpression 
 		traitDie: { quantity: 1, sides: 4 }, // default d4
 		wildDie: { quantity: 1, sides: 6 }, // default d6
 		targetHighest: 1,
+		targetNumber: 4, // default target number for trait rolls
 		validationMessages: [],
 	};
 

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -129,7 +129,6 @@ export function formatRollResult(result: FullRollResult): string {
  */
 export function formatTraitResult(result: FullTraitResult): string {
 	const { traitDieResult } = result;
-	const hasTargetNumber = result.targetNumber !== undefined;
 	const hasCriticalFailure = traitDieResult.isCriticalFailure;
 	const globalMod = result.globalModifier || 0;
 
@@ -161,10 +160,7 @@ export function formatTraitResult(result: FullTraitResult): string {
 			return "discarded";
 		}
 
-		if (!hasTargetNumber) {
-			return "";
-		}
-
+		// For the chosen die, always show the actual state (trait rolls always have target numbers)
 		switch (state) {
 			case ExpressionState.Raise:
 				return "raise";


### PR DESCRIPTION
Introduce a default target number for trait expressions, ensuring consistent behavior when no target number is specified. Update related tests to reflect these changes and verify correct formatting of results.