### PR TITLE
Add help command tests and improve help message formatting

### DIFF
--- a/src/tests/messages.spec.ts
+++ b/src/tests/messages.spec.ts
@@ -7,9 +7,33 @@ import {
 	getCommandConfig,
 	getAvailableCommands,
 } from "../utils/messages.js";
+import { HELP_ENABLED_COMMANDS } from "../utils/constants.js";
 import messages from "../utils/messages.json" with { type: "json" };
 
 describe("Command Messages", () => {
+	describe("getAvailableCommands", () => {
+		it("should return the expected help-enabled commands", () => {
+			const availableCommands = getAvailableCommands();
+
+			// Should return the exact commands from HELP_ENABLED_COMMANDS
+			expect(availableCommands).toEqual([...HELP_ENABLED_COMMANDS]);
+			expect(availableCommands).toHaveLength(HELP_ENABLED_COMMANDS.length);
+		});
+		it("should return array of strings", () => {
+			const availableCommands = getAvailableCommands();
+			expect(Array.isArray(availableCommands)).toBe(true);
+			availableCommands.forEach((command) => {
+				expect(typeof command).toBe("string");
+				expect(command.length).toBeGreaterThan(0);
+			});
+		});
+
+		it("should not include help command in the list", () => {
+			const availableCommands = getAvailableCommands();
+			expect(availableCommands).not.toContain("help");
+		});
+	});
+
 	describe("getCommandConfig", () => {
 		it("should return config for valid command", () => {
 			const config = getCommandConfig("roll");
@@ -43,16 +67,16 @@ describe("Command Messages", () => {
 
 			// Should contain help structure from configuration
 			expect(helpText).toContain(messages.help.title);
-			expect(helpText).toContain(messages.help.commandListIntro);
 			expect(helpText).toContain(messages.help.detailedHelpPrompt);
+			expect(helpText).toContain("**Quick Overview of Options:**");
 
-			// Should include all available commands
+			// Should include all available commands with new format
 			for (const commandName of availableCommands) {
 				expect(helpText).toContain(`**/${commandName}**`);
+				expect(helpText).toContain("&mdash;");
 			}
 		});
 	});
-
 	describe("formatDetailedCommandHelp", () => {
 		it("should format detailed help for all valid commands using configuration", () => {
 			const availableCommands = getAvailableCommands();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -55,3 +55,6 @@ export const GAME_RULES = {
 	RAISE_THRESHOLD: 4, // Amount above target number required for a "raise"
 	VALID_DICE_SIDES: [4, 6, 8, 10, 12, 20, 100] as const, // Valid dice sides for trait dice
 } as const;
+
+// Commands that should appear in the help system
+export const HELP_ENABLED_COMMANDS = ["roll", "trait"] as const;

--- a/src/utils/messages.json
+++ b/src/utils/messages.json
@@ -3,7 +3,7 @@
         "title": "🎲 Game Assist Bot Commands",
         "description": "A Discord bot for rolling dice and making trait checks. Use the commands below:",
         "commandListIntro": "**Available Commands:**",
-        "commandFormat": "• **/{name}** - {description}",
+        "commandFormat": "• **/{name}** `{formula}` - {description}",
         "detailedHelpPrompt": "Use `/help {command}` for detailed help on a specific command."
     },
     "commands": {


### PR DESCRIPTION
Introduce tests for `getAvailableCommands` to validate the expected help-enabled commands. Enhance the help message format to include command formulas and a quick overview section for better user guidance.