### PR TITLE
Enhance critical failure detection and formatting logic

### DIFF
--- a/src/tests/responses.test.ts
+++ b/src/tests/responses.test.ts
@@ -351,7 +351,7 @@ describe("formatRollResult", () => {
 			};
 
 			const result = formatRollResult(mockResult);
-			expect(result).toBe("1d4 [1] - 2 = **-1** failed\n❗**CRITICAL FAILURE**");
+			expect(result).toBe("1d4 [1] - 2 = **-1** failed"); // No critical failure with only 1 die
 		});
 
 		it("should format positive global modifier", () => {
@@ -462,6 +462,36 @@ describe("formatRollResult", () => {
 
 			const result = formatRollResult(mockResult);
 			expect(result).toBe("1d8 [1] + 2 = **3** failed\n1d6 [3] + 2 = **5** success");
+		});
+
+		it("should NOT show critical failure without target number", () => {
+			const mockResult: FullRollResult = {
+				expressionResults: [
+					{
+						diceGroupResults: [
+							{
+								result: {
+									originalGroup: { quantity: 2, sides: 6 },
+									rolls: [
+										[1, false, false],
+										[1, false, false],
+									],
+									total: 2,
+								},
+								operator: "+",
+							},
+						],
+						total: 2,
+						state: ExpressionState.NotApplicable,
+					},
+				],
+				grandTotal: 2,
+				// No targetNumber defined
+			};
+
+			const result = formatRollResult(mockResult);
+			expect(result).toBe("2d6 [1, 1] = **2**"); // No critical failure notice
+			expect(result).not.toContain("❗**CRITICAL FAILURE**");
 		});
 
 		it("should format with raw expression and emoji", () => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -54,6 +54,7 @@ export const GAME_RULES = {
 	// Game mechanics constants
 	RAISE_THRESHOLD: 4, // Amount above target number required for a "raise"
 	VALID_DICE_SIDES: [4, 6, 8, 10, 12, 20, 100] as const, // Valid dice sides for trait dice
+	MIN_CRITICAL_FAILURE_DICE: 2, // Minimum number of dice rolled to trigger critical failure
 } as const;
 
 // Commands that should appear in the help system

--- a/src/utils/dice.ts
+++ b/src/utils/dice.ts
@@ -95,7 +95,7 @@ export async function rollExpression(expression: {
 
 export function isCriticalFailure(expressionResult: ExpressionResult): boolean {
 	// Check if all non-dropped dice in this expression rolled 1s
-	let hasAnyActiveDice = false;
+	let totalActiveDiceCount = 0;
 
 	for (const { result: groupResult } of expressionResult.diceGroupResults) {
 		// Skip pure number modifiers (quantity: 0)
@@ -111,20 +111,18 @@ export function isCriticalFailure(expressionResult: ExpressionResult): boolean {
 			return false;
 		}
 
-		// Check if this group has any active dice at all
+		// Count active dice in this group
 		const activeDice = groupResult.rolls.filter(([, , dropped]) => !dropped);
-		if (activeDice.length > 0) {
-			hasAnyActiveDice = true;
-		}
+		totalActiveDiceCount += activeDice.length;
 	}
 
-	// Critical failure only if we had active dice and none rolled > 1
-	return hasAnyActiveDice;
+	// Critical failure only if we had enough active dice and none rolled > 1
+	return totalActiveDiceCount >= GAME_RULES.MIN_CRITICAL_FAILURE_DICE;
 }
 
 export function isFullRollCriticalFailure(fullResult: FullRollResult): boolean {
 	// Check if ALL dice across ALL expressions rolled 1s (excluding dropped dice and pure number modifiers)
-	let hasAnyActiveDice = false;
+	let totalActiveDiceCount = 0;
 
 	for (const expr of fullResult.expressionResults) {
 		for (const { result: groupResult } of expr.diceGroupResults) {
@@ -141,16 +139,14 @@ export function isFullRollCriticalFailure(fullResult: FullRollResult): boolean {
 				return false;
 			}
 
-			// Check if this group has any active dice at all
+			// Count active dice in this group
 			const activeDice = groupResult.rolls.filter(([, , dropped]) => !dropped);
-			if (activeDice.length > 0) {
-				hasAnyActiveDice = true;
-			}
+			totalActiveDiceCount += activeDice.length;
 		}
 	}
 
-	// Critical failure only if we had active dice and ALL of them rolled 1s
-	return hasAnyActiveDice;
+	// Critical failure only if we had enough active dice and ALL of them rolled 1s
+	return totalActiveDiceCount >= GAME_RULES.MIN_CRITICAL_FAILURE_DICE;
 }
 
 export async function rollParsedExpression(parsed: RollSpecification, rawExpression?: string): Promise<FullRollResult> {

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -112,8 +112,8 @@ export function formatRollResult(result: FullRollResult): string {
 	// Add results without quote formatting (bright)
 	response += expressionLines.join("\n");
 
-	// Add critical failure notice if any expression had one
-	if (hasCriticalFailure) {
+	// Add critical failure notice if any expression had one AND there's a target number
+	if (hasCriticalFailure && result.targetNumber !== undefined) {
 		response += "\n❗**CRITICAL FAILURE**";
 	}
 


### PR DESCRIPTION
Improve critical failure detection by requiring a minimum of two active dice and adjust formatting to exclude critical failure notices when only one die is rolled or when no target number is defined. Introduce a constant for minimum dice required for critical failure.