### PR TITLE
Make error messages ephemeral in handleDiceCommand function

### DIFF
--- a/src/utils/command-handler.ts
+++ b/src/utils/command-handler.ts
@@ -48,7 +48,7 @@ export async function handleDiceCommand<TParseData extends ParsedExpression, TEx
 	// Step 2: Check for errors and show help if invalid
 	if (!config.validateParseResult(parseResult)) {
 		const errorMessage = formatErrorMessage(config.commandName, input, parseResult.validationMessages);
-		await interaction.reply(errorMessage);
+		await interaction.reply({ content: errorMessage, flags: 1 << 6 }); // MessageFlags.Ephemeral
 		return;
 	}
 


### PR DESCRIPTION
Change error message replies to be ephemeral, ensuring they are only visible to the user who triggered the command.