### PR TITLE
Enhance dice expression parsing: support shorthand for target numbers and raises

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,12 @@ The `/roll` command supports a powerful and flexible dice notation system:
 - `5d6dl1` - Roll 5d6, drop the lowest 1 die
 
 ### Target Numbers (Success Counting)
-- `5d6 tn4` - Roll 5d6, count successes (dice that rolled 4 or higher)
+- `5d6 tn4` or `5d6 t4` - Roll 5d6, count successes (dice that rolled 4 or higher)
 - `3d8!! tn6` - Roll 3d8 with infinite exploding, count successes against target 6
+- `2d6;1d8;1d4 tn4 th2` - Roll three expressions, count only the top 2 that meet or exceed TN 4
+- **Target Highest**: Use `th<N>` with target numbers to count only the top N successful expressions
+- **Raises**: Automatically calculated as target + 4 (e.g., target 6 requires 10+ for a raise)
+- **Note**: Both `t` and `tn` mean the same thing (target number); `th` only works when `t`/`tn` is specified
 
 ### Global Modifiers
 - `2d6 (+3)` - Roll 2d6 and add 3 to the total result
@@ -175,28 +179,30 @@ The `/trait` command implements Savage Worlds trait roll mechanics with a trait 
 ### Basic Trait Rolls
 - `d8` - Roll d8 trait die + d6 wild die (defaults to TN 4)
 - `d10+1` - Roll d10 trait die + d6 wild die with +1 modifier
-- `d6 tn6` - Roll d6 trait die + d6 wild die against target number 6
+- `d6 tn6` or `d6 t6` - Roll d6 trait die + d6 wild die against target number 6
 
 ### Wild Die Override
 - `d8 wd8` - Roll d8 trait die + d8 wild die (override default d6)
 - `d10 wd6` - Roll d10 trait die + d6 wild die (explicit wild die)
 
 ### Full Syntax
-- `1d8 wd6 th1 (+1) tn4` - Complete notation with all components
-- `d12 wd8 (+2) tn6` - Common usage with override and modifier
+- `1d8 wd6 (+1) tn4` - Complete notation: trait die, wild die, modifier, target number
+- `d12 wd8 (+2) tn6` - Common usage with wild die override and modifier
+- `d8 wd6 th1 tn4` - Explicit `th1` (unnecessary since it's always 1, but valid)
 
 ### Components
 - **Trait Die**: `d4`, `d6`, `d8`, `d10`, `d12` - Player's skill/attribute die
-- **Wild Die**: `wd6` (default), `wd8`, `wd10`, etc. - Usually d6, manually specified for larger dice
+- **Wild Die**: `wd6` (default), `wd8`, `wd10`, etc. - Usually d6, can be overridden
 - **Global Modifier**: `+1`, `(-2)` - Applied to both dice totals
-- **Target Number**: `tn4` (default), `tn6`, `tn8` - Difficulty of the task
-- **Target Highest**: `th1` - Number of results to compare (always 1 for traits)
+- **Target Number**: `tn4` or `t4` (default TN 4), `tn6`, `t8` - Difficulty threshold (`t` and `tn` are equivalent)
+- **Target Highest**: Always `th1` (hardcoded, compares trait die vs wild die to keep the higher result)
 
 ### Special Rules
 - **Exploding Dice**: Both dice explode infinitely on maximum value (ace)
-- **Keep Higher**: The higher total (trait or wild + modifiers) is used
+- **Keep Higher**: The higher result between trait die and wild die is used (inherent `th1` behavior)
 - **Critical Failure**: Occurs when both dice roll natural 1s, regardless of modifiers
 - **States**: Success (≥TN), Raise (≥TN+4), Failure (<TN)
+- **Raises**: Automatically calculated as target number + 4 (same as `/roll`)
 
 ### Trait Examples
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -182,9 +182,15 @@ interface RollOutcome {
 Parses a dice expression string into a structured specification.
 
 **Parameters**:
-- `expression`: String like "2d6+3", "1d8!!;1d6", "4d6kh3 tn4"
+- `expression`: String like "2d6+3", "1d8!!;1d6", "4d6kh3 t4" or "4d6kh3 tn4"
 
 **Returns**: `RollSpecification` with validation messages
+
+**Supported Syntax**:
+- Target Number: `tn<number>` or `t<number>` (e.g., `tn4`, `t6`) - sets the difficulty threshold (`t` and `tn` are equivalent)
+- Target Highest: `th<number>` (e.g., `th2`) - when used with target number, counts only the top N successful expressions
+- Raises: Automatically calculated as target number + 4 (e.g., target 6 requires 10 for a raise)
+- Note: `th` requires `t`/`tn` to be specified
 
 **Examples**:
 ```typescript
@@ -197,6 +203,15 @@ const result = parseRollExpression("2d6+3");
 const complex = parseRollExpression("1d8!!;1d6 tn4");
 // result.expressions: [expression1, expression2]
 // result.targetNumber: 4
+
+const shorthand = parseRollExpression("2d6 t8");
+// Equivalent to "2d6 tn8" (both use the same target number)
+// result.targetNumber: 8
+
+const withTargetHighest = parseRollExpression("1d6;2d6;3d6 tn4 th2");
+// Roll three expressions, count only top 2 that meet TN 4
+// result.targetNumber: 4
+// result.targetHighest: 2
 ```
 
 #### `parseTraitExpression(expression: string): TraitSpecification`
@@ -204,9 +219,15 @@ const complex = parseRollExpression("1d8!!;1d6 tn4");
 Parses a Savage Worlds trait expression.
 
 **Parameters**:
-- `expression`: String like "d8", "d10+1 tn6", "d4 wd6 (+2) tn4"
+- `expression`: String like "d8", "d10+1 t6", "d4 wd6 (+2) tn4"
 
 **Returns**: `TraitSpecification` with validation messages
+
+**Supported Syntax**:
+- Target Number: `tn<number>` or `t<number>` (e.g., `tn4`, `t6`) - sets the difficulty threshold (`t` and `tn` are equivalent)
+- Target Highest: `th1` (default, always 1 for single trait rolls) - compares trait vs wild die to keep highest
+- Raises: Automatically calculated as target number + 4
+- Note: Unlike `/roll`, trait `th` is always 1 and represents choosing between trait and wild die
 
 **Examples**:
 ```typescript
@@ -215,6 +236,11 @@ const result = parseTraitExpression("d8+1 tn6");
 // result.wildDie: { quantity: 1, sides: 6, infinite: true }
 // result.globalModifier: 1
 // result.targetNumber: 6
+
+const shorthand = parseTraitExpression("d10 t6 th1");
+// Equivalent to "d10 tn6 th1" (t and tn both set target number)
+// result.targetNumber: 6
+// result.targetHighest: 1
 ```
 
 ### Execution Functions

--- a/src/tests/parse.spec.ts
+++ b/src/tests/parse.spec.ts
@@ -141,6 +141,17 @@ describe("parseRollExpression", () => {
 			expect(result.targetNumber).toBe(8);
 		});
 
+		it("should parse target number with shorthand 't'", () => {
+			const result = parseRollExpression("2d6 t8");
+			expect(result.targetNumber).toBe(8);
+		});
+
+		it("should treat 't' and 'tn' as equivalent", () => {
+			const resultTn = parseRollExpression("2d6 tn8");
+			const resultT = parseRollExpression("2d6 t8");
+			expect(resultTn.targetNumber).toBe(resultT.targetNumber);
+		});
+
 		it("should parse global modifier with parentheses", () => {
 			const result = parseRollExpression("2d6 (+3)");
 			expect(result.globalModifier).toBe(3);
@@ -158,6 +169,12 @@ describe("parseRollExpression", () => {
 
 		it("should parse both target number and global modifier", () => {
 			const result = parseRollExpression("2d6 tn8 (+2)");
+			expect(result.targetNumber).toBe(8);
+			expect(result.globalModifier).toBe(2);
+		});
+
+		it("should parse target number shorthand with global modifier", () => {
+			const result = parseRollExpression("2d6 t8 (+2)");
 			expect(result.targetNumber).toBe(8);
 			expect(result.globalModifier).toBe(2);
 		});
@@ -271,8 +288,34 @@ describe("parseTraitExpression", () => {
 			expect(result.targetNumber).toBe(6);
 		});
 
+		it("should parse target number with shorthand 't'", () => {
+			const result = parseTraitExpression("d8 t6");
+			expect(result.targetNumber).toBe(6);
+		});
+
+		it("should treat 't' and 'tn' as equivalent in trait expressions", () => {
+			const resultTn = parseTraitExpression("d8 tn6");
+			const resultT = parseTraitExpression("d8 t6");
+			expect(resultTn.targetNumber).toBe(resultT.targetNumber);
+		});
+
 		it("should parse target highest", () => {
 			const result = parseTraitExpression("d8 th2");
+			expect(result.targetHighest).toBe(2);
+		});
+
+		it("should distinguish between 't' (target number) and 'th' (target highest)", () => {
+			const resultT = parseTraitExpression("d8 t6");
+			const resultTh = parseTraitExpression("d8 th2");
+			expect(resultT.targetNumber).toBe(6);
+			expect(resultT.targetHighest).toBe(1); // default
+			expect(resultTh.targetNumber).toBe(4); // default
+			expect(resultTh.targetHighest).toBe(2);
+		});
+
+		it("should parse both target number shorthand and target highest", () => {
+			const result = parseTraitExpression("d8 t6 th2");
+			expect(result.targetNumber).toBe(6);
 			expect(result.targetHighest).toBe(2);
 		});
 	});

--- a/src/tests/roll-th.spec.ts
+++ b/src/tests/roll-th.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { parseRollExpression } from "../utils/parse.js";
+
+describe("parseRollExpression - target highest (th) support", () => {
+	describe("basic th parsing", () => {
+		it("should parse th with target number", () => {
+			const result = parseRollExpression("2d6 tn4 th2");
+			expect(result.targetNumber).toBe(4);
+			expect(result.targetHighest).toBe(2);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse th with shorthand t", () => {
+			const result = parseRollExpression("2d6 t4 th2");
+			expect(result.targetNumber).toBe(4);
+			expect(result.targetHighest).toBe(2);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse th with multiple expressions", () => {
+			const result = parseRollExpression("1d6;2d6;3d6 tn4 th2");
+			expect(result.targetNumber).toBe(4);
+			expect(result.targetHighest).toBe(2);
+			expect(result.expressions).toHaveLength(3);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse th1 as default", () => {
+			const result = parseRollExpression("2d6 tn4 th1");
+			expect(result.targetNumber).toBe(4);
+			expect(result.targetHighest).toBe(1);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+	});
+
+	describe("th validation", () => {
+		it("should require target number when th is specified", () => {
+			const result = parseRollExpression("2d6 th2");
+			expect(result.targetNumber).toBeUndefined();
+			expect(result.targetHighest).toBeUndefined();
+			expect(result.validationMessages).toContain(
+				"Target highest (th) requires target number (t/tn) to be specified",
+			);
+		});
+
+		it("should not parse th without target number", () => {
+			const result = parseRollExpression("1d6;2d6;3d6 th2");
+			expect(result.targetNumber).toBeUndefined();
+			expect(result.targetHighest).toBeUndefined();
+			expect(result.validationMessages.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe("th with other modifiers", () => {
+		it("should parse th with global modifier", () => {
+			const result = parseRollExpression("2d6 tn4 th2 (+3)");
+			expect(result.targetNumber).toBe(4);
+			expect(result.targetHighest).toBe(2);
+			expect(result.globalModifier).toBe(3);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse th with complex expressions", () => {
+			const result = parseRollExpression("1d6!!;2d8kh1;3d10dl1 tn6 th2");
+			expect(result.targetNumber).toBe(6);
+			expect(result.targetHighest).toBe(2);
+			expect(result.expressions).toHaveLength(3);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+	});
+
+	describe("th order independence", () => {
+		it("should parse th before tn", () => {
+			const result = parseRollExpression("2d6 th2 tn4");
+			expect(result.targetNumber).toBe(4);
+			expect(result.targetHighest).toBe(2);
+			expect(result.validationMessages).toHaveLength(0);
+		});
+
+		it("should parse with global modifier in different positions", () => {
+			const result1 = parseRollExpression("2d6 (+2) tn4 th1");
+			const result2 = parseRollExpression("2d6 tn4 th1 (+2)");
+			const result3 = parseRollExpression("2d6 th1 (+2) tn4");
+
+			expect(result1.targetNumber).toBe(4);
+			expect(result1.targetHighest).toBe(1);
+			expect(result1.globalModifier).toBe(2);
+
+			expect(result2.targetNumber).toBe(4);
+			expect(result2.targetHighest).toBe(1);
+			expect(result2.globalModifier).toBe(2);
+
+			expect(result3.targetNumber).toBe(4);
+			expect(result3.targetHighest).toBe(1);
+			expect(result3.globalModifier).toBe(2);
+		});
+	});
+});

--- a/src/tests/trait.spec.ts
+++ b/src/tests/trait.spec.ts
@@ -200,6 +200,56 @@ describe("trait roll mechanics", () => {
 			expect(result.traitDieResult.finalTotal).toBe(9); // trait chosen
 		});
 
+		it("should calculate raises relative to target number (TN 4)", () => {
+			// Roll 8 with target 4 should be a raise (4 + 4 = 8)
+			mockRandomInt.mockReturnValueOnce(8).mockReturnValueOnce(3);
+
+			const parsed = parseTraitExpression("d10 tn4");
+			const result = rollParsedTraitExpression(parsed);
+
+			expect(result.traitDieResult.state).toBe(ExpressionState.Raise);
+			expect(result.traitDieResult.finalTotal).toBe(8);
+		});
+
+		it("should calculate raises relative to target number (TN 6)", () => {
+			// Roll 10 with target 6 should be a raise (6 + 4 = 10)
+			mockRandomInt.mockReturnValueOnce(10).mockReturnValueOnce(3);
+
+			const parsed = parseTraitExpression("d12 tn6");
+			const result = rollParsedTraitExpression(parsed);
+
+			// Target 6, raise at 10 (6 + 4), not at 8
+			expect(result.traitDieResult.state).toBe(ExpressionState.Raise);
+			expect(result.traitDieResult.finalTotal).toBe(10);
+		});
+
+		it("should not raise when exactly 4 below threshold (TN 6)", () => {
+			// Roll 8 with target 6 should be success but not raise (need 10 for raise)
+			mockRandomInt.mockReturnValueOnce(8).mockReturnValueOnce(3);
+
+			const parsed = parseTraitExpression("d10 tn6");
+			const result = rollParsedTraitExpression(parsed);
+
+			// Target 6, need 10 for raise, got 8
+			expect(result.traitDieResult.state).toBe(ExpressionState.Success);
+			expect(result.traitDieResult.finalTotal).toBe(8);
+		});
+
+		it("should calculate raises relative to target number (TN 10)", () => {
+			// Roll 14 with target 10 should be a raise (10 + 4 = 14)
+			mockRandomInt
+				.mockReturnValueOnce(10)
+				.mockReturnValueOnce(4) // trait: 10 + 4 = 14
+				.mockReturnValueOnce(3); // wild: 3
+
+			const parsed = parseTraitExpression("d10 tn10");
+			const result = rollParsedTraitExpression(parsed);
+
+			// Target 10, raise at 14 (10 + 4), not at 8
+			expect(result.traitDieResult.state).toBe(ExpressionState.Raise);
+			expect(result.traitDieResult.finalTotal).toBe(14);
+		});
+
 		it("should determine failure state", () => {
 			// Rolls to 3, target 6 = failure
 			mockRandomInt.mockReturnValueOnce(2).mockReturnValueOnce(3);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -29,6 +29,7 @@ export interface ExpressionResult {
 export interface RollSpecification {
 	expressions: Array<{ diceGroups: Array<{ group: DiceGroup; operator: "+" | "-" }> }>;
 	targetNumber?: number;
+	targetHighest?: number;
 	globalModifier?: number;
 	rawExpression?: string;
 	validationMessages: string[];
@@ -38,10 +39,10 @@ export interface TraitSpecification {
 	traitDie: DiceGroup;
 	wildDie: DiceGroup;
 	targetNumber?: number;
+	targetHighest?: number;
 	globalModifier?: number;
 	rawExpression?: string;
 	validationMessages: string[];
-	targetHighest?: number;
 }
 
 export interface StandardRollDetails {


### PR DESCRIPTION
Improve parsing of dice expressions by adding shorthand for target numbers and raises, along with validation for the target highest. This update allows for more concise input while maintaining functionality.