### PR TITLE
Update trait roll response text

### DIFF
--- a/src/tests/trait-format.test.ts
+++ b/src/tests/trait-format.test.ts
@@ -65,7 +65,7 @@ describe("trait response formatting", () => {
 
 		const formatted = formatTraitResult(fullResult, createMockUserContext());
 
-		expect(formatted).toContain("> 🎲 **TestUser** *tried trait roll d8*");
+		expect(formatted).toContain("> 🎲 **TestUser** *rolled trait d8*");
 		expect(formatted).toContain("Trait Die: 1d8 [5] = **5**");
 		expect(formatted).toContain("Wild Die: 1d6 [3] = **3** discarded");
 		expect(formatted).not.toContain("CRITICAL FAILURE");
@@ -96,7 +96,7 @@ describe("trait response formatting", () => {
 
 		const formatted = formatTraitResult(fullResult, createMockUserContext());
 
-		expect(formatted).toContain("> 🎲 **TestUser** *tried trait roll d8+2 tn6*");
+		expect(formatted).toContain("> 🎲 **TestUser** *rolled trait d8+2 tn6*");
 		expect(formatted).toContain("Trait Die: 1d8 [4] +2 = **6** discarded");
 		expect(formatted).toContain("Wild Die: 1d6 [6] +2 = **8** success");
 	});
@@ -149,7 +149,7 @@ describe("trait response formatting", () => {
 
 		const formatted = formatTraitResult(fullResult, createMockUserContext());
 
-		expect(formatted).toContain("> 🎲 **TestUser** *tried trait roll d8+2 tn6*");
+		expect(formatted).toContain("> 🎲 **TestUser** *rolled trait d8+2 tn6*");
 		expect(formatted).toContain("Trait Die: 1d8 [1] +2 = **3**");
 		expect(formatted).toContain("Wild Die: 1d6 [1] +2 = **3**");
 		expect(formatted).toContain("❗ **CRITICAL FAILURE**");

--- a/src/tests/username-display.test.ts
+++ b/src/tests/username-display.test.ts
@@ -151,7 +151,7 @@ describe("Username display in responses", () => {
 
 			const result = formatTraitResult(mockResult, createMockUserContext("PlayerName"));
 			expect(result).toContain("**PlayerName**");
-			expect(result).toContain("*tried trait roll d8+2*");
+			expect(result).toContain("*rolled trait d8+2*");
 		});
 
 		it("should work without username", () => {
@@ -180,9 +180,9 @@ describe("Username display in responses", () => {
 
 			const result = formatTraitResult(mockResult, createMockUserContext("User"));
 			// Should have username in bold in the header
-			expect(result).toMatch(/\*\*User\*\* \*tried trait roll/);
+			expect(result).toMatch(/\*\*User\*\* \*rolled trait/);
 			// Should have the roll expression (in the header, in italics)
-			expect(result).toContain("*tried trait roll d8*");
+			expect(result).toContain("*rolled trait d8*");
 			// Should have the results in bold
 			expect(result).toContain("**5**");
 		});

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -138,7 +138,7 @@ export function formatTraitResult(result: FullTraitResult, userContext: UserCont
 	// Build the original expression for display
 	let originalExpression = "";
 	if (result.rawExpression) {
-		originalExpression = `> 🎲 **${userContext.markdownSafeName}** *tried trait roll ${result.rawExpression}*\n`;
+		originalExpression = `> 🎲 **${userContext.markdownSafeName}** *rolled trait ${result.rawExpression}*\n`;
 	}
 
 	// Helper function to format dice rolls for display


### PR DESCRIPTION
"Change the response text from 'tried trait roll' to 'rolled trait' for clarity in user feedback."